### PR TITLE
fixing branch filter name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
           requires:
             - build
       # - hold:


### PR DESCRIPTION
Closes #20 

Fixes the bad branch name in the build filter.