### PR TITLE
changes to get correct screenshots for appstore

### DIFF
--- a/Ironlog.xcodeproj/xcshareddata/xcschemes/IronlogUITests.xcscheme
+++ b/Ironlog.xcodeproj/xcshareddata/xcschemes/IronlogUITests.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "053FDDEF272F2DC5002D6D9D"
+               BuildableName = "IronlogUITests.xctest"
+               BlueprintName = "IronlogUITests"
+               ReferencedContainer = "container:Ironlog.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "053FDDEF272F2DC5002D6D9D"
+               BuildableName = "IronlogUITests.xctest"
+               BlueprintName = "IronlogUITests"
+               ReferencedContainer = "container:Ironlog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "053FDDEF272F2DC5002D6D9D"
+            BuildableName = "IronlogUITests.xctest"
+            BlueprintName = "IronlogUITests"
+            ReferencedContainer = "container:Ironlog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,8 @@ platform :ios do
   desc "Build and run tests"
   lane :test do
     scan(
-      include_simulator_logs: false
+      include_simulator_logs: false,
+      scheme: "Ironlog"
     )
   end
 

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -2,7 +2,8 @@
 
 # A list of devices you want to take the screenshots from
 devices([
-    "iPhone 14"
+  "iPhone 14 Plus",
+  "iPhone 8 Plus"
 ])
 
 languages([
@@ -10,7 +11,7 @@ languages([
 ])
 
 # The name of the scheme which contains the UI Tests
-# scheme("SchemeName")
+scheme("IronlogUITests")
 
 # Where should the resulting screenshots be stored?
 # output_directory("./screenshots")
@@ -20,6 +21,8 @@ clear_previous_screenshots(true)
 
 # Remove the '#' to set the status bar to 9:41 AM, and show full battery and reception. See also override_status_bar_arguments for custom options.
 override_status_bar(true)
+
+reinstall_app(true)
 
 # Arguments to pass to the app on launch. See https://docs.fastlane.tools/actions/snapshot/#launch-arguments
 # launch_arguments(["-favColor red"])


### PR DESCRIPTION
This adds some changes to the snapfile for fastlane snapshot to make sure we're getting the correct screenshot sizes for iPhone 14 Plus and iPhone 8 Plus.