### PR TITLE
Feature/move to cd proper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - run: |
-          ls -la /tmp/workspace/gym
       - checkout
       - ruby/install-deps
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 jobs:
 
-  build-and-run-tests:
+  run-tests:
     macos: 
       xcode: 14.0.1
     working_directory: /Users/distiller/project
@@ -73,6 +73,8 @@ jobs:
       FASTLANE_LANE: release_appstore
     shell: /bin/bash --login -o pipefail
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - checkout
       - ruby/install-deps
       - run:
@@ -85,22 +87,22 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - build-and-run-tests
+      - run-tests
       - build-for-appstore:
           requires:
             - build-and-run-tests
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
+          filters:
+            branches:
+              only:
+                - main
 
       - release-testflight:
           requires:
             - build-for-appstore
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
+          filters:
+            branches:
+              only:
+                - main
 
       - release-appstore:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: |
-          ls -la /tmp/workspace
+          ls -la /tmp/workspace/distiller/project
       - checkout
       - ruby/install-deps
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: |
-          ls -la /tmp/workspace/
+          ls -la /tmp/workspace/gym
       - checkout
       - ruby/install-deps
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,10 @@ jobs:
           command: bundle exec fastlane $FASTLANE_LANE
       - store_artifacts:
           path: output
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - "output"
 
   release-testflight:
     macos: 
@@ -50,6 +54,8 @@ jobs:
       FASTLANE_LANE: release_testflight
     shell: /bin/bash --login -o pipefail
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - checkout
       - ruby/install-deps
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,13 +80,17 @@ workflows:
   build-test:
     jobs:
       - build-and-run-tests
-      - build-for-appstore
+      - build-for-appstore:
+          requires:
+            - build-and-run-tests
           # filters:
           #   branches:
           #     only:
           #       - main
 
-      - release-testflight
+      - release-testflight:
+          requires:
+            - build-for-appstore
           # filters:
           #   branches:
           #     only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ orbs:
   ruby: circleci/ruby@1.2.0
 
 jobs:
-  build-and-test:
+
+  build-and-run-tests:
     macos: 
       xcode: 14.0.1
     working_directory: /Users/distiller/project
@@ -22,13 +23,14 @@ jobs:
           path: output
       - store_test_results:
           path: output/scan
-  release-beta:
+
+  build-for-appstore:
     macos: 
       xcode: 14.0.1
     working_directory: /Users/distiller/project
     environment:
       FL_OUTPUT_DIR: output
-      FASTLANE_LANE: release_internal_beta
+      FASTLANE_LANE: build_for_appstore
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
@@ -38,6 +40,24 @@ jobs:
           command: bundle exec fastlane $FASTLANE_LANE
       - store_artifacts:
           path: output
+
+  release-testflight:
+    macos: 
+      xcode: 14.0.1
+    working_directory: /Users/distiller/project
+    environment:
+      FL_OUTPUT_DIR: output
+      FASTLANE_LANE: release_testflight
+    shell: /bin/bash --login -o pipefail
+    steps:
+      - checkout
+      - ruby/install-deps
+      - run:
+          name: fastlane
+          command: bundle exec fastlane $FASTLANE_LANE
+      - store_artifacts:
+          path: output
+
   release-appstore:
     macos: 
       xcode: 14.0.1
@@ -54,29 +74,25 @@ jobs:
           command: bundle exec fastlane $FASTLANE_LANE
       - store_artifacts:
           path: output
+
 workflows:
   version: 2
   build-test:
     jobs:
-      - build-and-test
-  testflight-release:
-    jobs:
-      - release-beta:
-          filters:
-            branches:
-              only:
-                - main
-  appstore-release:
-    jobs:
-      - hold:
-          type: approval
-          filters:
-            branches:
-              only:
-                - main
+      - build-and-run-tests
+      - build-for-appstore
+          # filters:
+          #   branches:
+          #     only:
+          #       - main
+
+      - release-testflight
+          # filters:
+          #   branches:
+          #     only:
+          #       - main
+
       - release-appstore:
-          requires:
-            - hold
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - run: |
+          ls -la /tmp/workspace
       - checkout
       - ruby/install-deps
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: |
-          ls -la /tmp/workspace/distiller/project
+          ls -la /tmp/workspace/distiller/
       - checkout
       - ruby/install-deps
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - store_artifacts:
           path: output
       - persist_to_workspace:
-          root: workspace
+          root: gym
           paths:
             - "output"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
       - run-tests
       - build-for-appstore:
           requires:
-            - build-and-run-tests
+            - run-tests
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,9 @@ jobs:
       - store_artifacts:
           path: output
       - persist_to_workspace:
-          root: gym
+          root: output
           paths:
-            - "output"
+            - "gym"
 
   release-testflight:
     macos: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: |
-          ls -la /tmp/workspace/distiller/
+          ls -la /tmp/workspace/
       - checkout
       - ruby/install-deps
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,8 @@ workflows:
                 - main
 
       - release-appstore:
+          requires:
+            - build-for-appstore
           filters:
             branches:
               only:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,7 +51,7 @@ platform :ios do
   lane :release_appstore do
   app_store_connect_api_key
   upload_to_app_store(
-    ipa: "./output/gym/Ironlog.ipa",
+    ipa: "/tmp/workspace/gym/Ironlog.ipa",
     force: true,
     precheck_include_in_app_purchases: false
   )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,7 +41,7 @@ platform :ios do
   lane :release_testflight do
   app_store_connect_api_key
   upload_to_testflight(
-    ipa: "/tmp/workspace/output/gym/Ironlog.ipa",
+    ipa: "/tmp/workspace/gym/Ironlog.ipa",
     skip_waiting_for_build_processing: true,
     groups: ["Dev testing"],
     distribute_external: false)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,8 +41,8 @@ platform :ios do
   lane :release_testflight do
   app_store_connect_api_key
   upload_to_testflight(
-    ipa: "./output/gym/Ironlog.ipa"
-    skip_waiting_for_build_processing: true, 
+    ipa: "./output/gym/Ironlog.ipa",
+    skip_waiting_for_build_processing: true,
     groups: ["Dev testing"],
     distribute_external: false)
   end
@@ -51,7 +51,7 @@ platform :ios do
   lane :release_appstore do
   app_store_connect_api_key
   upload_to_app_store(
-    ipa: "./output/gym/Ironlog.ipa"
+    ipa: "./output/gym/Ironlog.ipa",
     force: true,
     precheck_include_in_app_purchases: false
   )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,7 +41,7 @@ platform :ios do
   lane :release_testflight do
   app_store_connect_api_key
   upload_to_testflight(
-    ipa: "./output/gym/Ironlog.ipa",
+    ipa: "/tmp/workspace/output/gym/Ironlog.ipa",
     skip_waiting_for_build_processing: true,
     groups: ["Dev testing"],
     distribute_external: false)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,7 +20,7 @@ platform :ios do
     setup_circle_ci
   end
 
-  desc "Build and run tests"
+  desc "run tests"
   lane :test do
     scan(
       include_simulator_logs: false,
@@ -28,30 +28,30 @@ platform :ios do
     )
   end
 
-  desc "Push a new release to Testflight internal beta"
-  lane :release_internal_beta do
+  desc "build for appstore"
+  lane :build_for_appstore do
+    match(type: "appstore", git_url: "git@github.com:bstauff/Ironlog.certs.git")
+    increment_build_number(
+      xcodeproj: "Ironlog.xcodeproj",
+      build_number: "$CIRCLE_BUILD_NUM")
+    build_app(scheme: "Ironlog", export_method: "app-store")
+  end
+
+  desc "release to Testflight"
+  lane :release_testflight do
   app_store_connect_api_key
-  match(type: "appstore", git_url: "git@github.com:bstauff/Ironlog.certs.git")
-  increment_build_number(
-    xcodeproj: "Ironlog.xcodeproj",
-    build_number: "$CIRCLE_BUILD_NUM")
-  build_app(scheme: "Ironlog", export_method: "app-store")
   upload_to_testflight(
+    ipa: "./output/gym/Ironlog.ipa"
     skip_waiting_for_build_processing: true, 
     groups: ["Dev testing"],
     distribute_external: false)
   end
 
-  desc "Push a new release to public AppStore"
+  desc "release to AppStore"
   lane :release_appstore do
   app_store_connect_api_key
-  match(type: "appstore", git_url: "git@github.com:bstauff/Ironlog.certs.git")
-  increment_build_number(
-    xcodeproj: "Ironlog.xcodeproj",
-    build_number: "$CIRCLE_BUILD_NUM")
-  capture_screenshots
-  build_app(scheme: "Ironlog", export_method: "app-store")
   upload_to_app_store(
+    ipa: "./output/gym/Ironlog.ipa"
     force: true,
     precheck_include_in_app_purchases: false
   )


### PR DESCRIPTION
Moving to a proper CD style pipeline for our CI/CD.

Going forward, everything will go out to App Store immediately upon a successful build and test.

We're going to need more automated UI tests to cover this.