### PR TITLE
change release to appstore to only promote the testflight build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ workflows:
 
       - release-appstore:
           requires:
-            - build-for-appstore
+            - release-testflight
           filters:
             branches:
               only:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,9 +51,13 @@ platform :ios do
   lane :release_appstore do
   app_store_connect_api_key
   upload_to_app_store(
-    ipa: "/tmp/workspace/gym/Ironlog.ipa",
     force: true,
-    precheck_include_in_app_purchases: false
+    precheck_include_in_app_purchases: false,
+    build_number: "$CIRCLE_BUILD_NUM",
+    skip_metadata: true,
+    skip_screenshots: true,
+    skip_binary_upload: true,
+    automatic_release: true
   )
   end
 end


### PR DESCRIPTION
Changing the CircleCI process to have the "release to App Store" step only promote the build that was uploaded by TestFlight.